### PR TITLE
redirect relax to mlc-ai/relax

### DIFF
--- a/.github/workflows/wheel_manylinux_nightly.yaml
+++ b/.github/workflows/wheel_manylinux_nightly.yaml
@@ -41,7 +41,7 @@ jobs:
         ln -s 3rdparty/tlcpack/common common
     - name: Checkout source
       run: |
-        git clone https://github.com/tlc-pack/relax tvm --recursive
+        git clone https://github.com/mlc-ai/relax tvm --recursive
     - name: Sync Package
       run: python common/sync_package.py --cuda ${{ matrix.config.cuda }} ${{ matrix.pkg }} --revision origin/relax
     - name: Build

--- a/.github/workflows/wheel_winmac_nightly.yaml
+++ b/.github/workflows/wheel_winmac_nightly.yaml
@@ -50,7 +50,7 @@ jobs:
         conda list
     - name: TVM checkout
       run: |
-        git clone https://github.com/tlc-pack/relax tvm --recursive
+        git clone https://github.com/mlc-ai/relax tvm --recursive
     - name: Sync Package
       run: python3 common/sync_package.py ${{ matrix.pkg }} --revision origin/relax
     - name: Build@MacOS


### PR DESCRIPTION
We create a relax fork for mlc course. This PR changes the building url in CI.

cc @tqchen 