### PR TITLE
Fix z3 static wheel smoke test path

### DIFF
--- a/.github/actions/z3-static-wheel/action.yml
+++ b/.github/actions/z3-static-wheel/action.yml
@@ -58,7 +58,7 @@ runs:
         CIBW_REPAIR_WHEEL_COMMAND_LINUX: bash -c 'mkdir -p "{dest_dir}" && cp "{wheel}" "{dest_dir}/"'
         CIBW_REPAIR_WHEEL_COMMAND_MACOS: bash -c 'mkdir -p "{dest_dir}" && cp "{wheel}" "{dest_dir}/"'
         CIBW_TEST_REQUIRES: cmake
-        CIBW_TEST_COMMAND: python {project}/scripts/smoke_test_staticlib.py
+        CIBW_TEST_COMMAND: python {project}/packages/z3-static/scripts/smoke_test_staticlib.py
       with:
         package-dir: packages/z3-static
         output-dir: wheelhouse

--- a/packages/z3-static/scripts/z3_static_builder.py
+++ b/packages/z3-static/scripts/z3_static_builder.py
@@ -51,6 +51,19 @@ def _copy_tree(src: Path, dst: Path) -> None:
         shutil.copytree(src, dst, dirs_exist_ok=True)
 
 
+def _normalize_metadata_library_dirs(static_dir: Path) -> None:
+    """Point staged CMake/pkg-config metadata at the normalized lib directory."""
+    metadata_files = [
+        *static_dir.glob("lib/cmake/z3/*.cmake"),
+        *static_dir.glob("lib/pkgconfig/*.pc"),
+    ]
+    for path in metadata_files:
+        text = path.read_text(encoding="utf-8")
+        normalized = text.replace("/lib64", "/lib")
+        if normalized != text:
+            path.write_text(normalized, encoding="utf-8")
+
+
 def main() -> None:
     tag = os.environ.get("STATICLIB_Z3_TAG", "z3-4.16.0")
     package_dir = Path(
@@ -106,6 +119,7 @@ def main() -> None:
     _copy_tree(install_dir / "lib", static_dir / "lib")
     _copy_tree(install_dir / "lib64", static_dir / "lib")
     _copy_tree(install_dir / "share", static_dir / "share")
+    _normalize_metadata_library_dirs(static_dir)
 
     license_src = source_dir / "LICENSE.txt"
     if not license_src.exists():


### PR DESCRIPTION
## Summary

- Fix the cibuildwheel smoke test command to point at the script under `packages/z3-static`.
- Normalize staged Z3 CMake/pkg-config metadata from `lib64` to the packaged `lib` directory so manylinux wheels can be consumed by CMake after installation.
- Build the smoke test with the Release configuration on Windows so MSVC does not link Debug objects against the Release `libz3.lib`.