### PR TITLE
Build z3 static smoke test as Release on Windows

### DIFF
--- a/packages/z3-static/scripts/smoke_test_staticlib.py
+++ b/packages/z3-static/scripts/smoke_test_staticlib.py
@@ -55,8 +55,12 @@ int main() {
         env = os.environ.copy()
         env["Z3_DIR"] = z3_static.get_cmake_dir()
         run([cmake, "-S", str(root), "-B", str(build), f"-DZ3_DIR={z3_static.get_cmake_dir()}"], cwd=root)
-        run([cmake, "--build", str(build)], cwd=root)
-        exe = build / ("smoke.exe" if sys.platform == "win32" else "smoke")
+        if sys.platform == "win32":
+            run([cmake, "--build", str(build), "--config", "Release"], cwd=root)
+            exe = build / "Release" / "smoke.exe"
+        else:
+            run([cmake, "--build", str(build)], cwd=root)
+            exe = build / "smoke"
         run([str(exe)], cwd=root)
 
 


### PR DESCRIPTION
## Summary

- Build the z3-static smoke test with the Release configuration on Windows.
- This avoids MSVC Debug/Release CRT mismatches when linking against the Release-built `libz3.lib`.