### PR TITLE
Retag z3 static Linux wheels as manylinux

### DIFF
--- a/.github/actions/z3-static-wheel/action.yml
+++ b/.github/actions/z3-static-wheel/action.yml
@@ -55,7 +55,11 @@ runs:
           STATICLIB_Z3_TAG="${{ inputs.z3-tag }}"
           STATICLIB_Z3_ALLOW_SOURCE_BUILD=1
           STATICLIB_Z3_PLAT_NAME="${{ inputs.platform-tag }}"
-        CIBW_REPAIR_WHEEL_COMMAND_LINUX: bash -c 'mkdir -p "{dest_dir}" && cp "{wheel}" "{dest_dir}/"'
+        CIBW_REPAIR_WHEEL_COMMAND_LINUX: >-
+          bash -c 'python -m pip install wheel &&
+          python -m wheel tags --remove --platform-tag "$STATICLIB_Z3_PLAT_NAME" "{wheel}" &&
+          mkdir -p "{dest_dir}" &&
+          cp "$(dirname "{wheel}")"/*.whl "{dest_dir}/"'
         CIBW_REPAIR_WHEEL_COMMAND_MACOS: bash -c 'mkdir -p "{dest_dir}" && cp "{wheel}" "{dest_dir}/"'
         CIBW_TEST_REQUIRES: cmake
         CIBW_TEST_COMMAND: python {project}/packages/z3-static/scripts/smoke_test_staticlib.py

--- a/.github/actions/z3-static-wheel/action.yml
+++ b/.github/actions/z3-static-wheel/action.yml
@@ -55,11 +55,7 @@ runs:
           STATICLIB_Z3_TAG="${{ inputs.z3-tag }}"
           STATICLIB_Z3_ALLOW_SOURCE_BUILD=1
           STATICLIB_Z3_PLAT_NAME="${{ inputs.platform-tag }}"
-        CIBW_REPAIR_WHEEL_COMMAND_LINUX: >-
-          bash -c 'python -m pip install wheel &&
-          python -m wheel tags --remove --platform-tag "$STATICLIB_Z3_PLAT_NAME" "{wheel}" &&
-          mkdir -p "{dest_dir}" &&
-          cp "$(dirname "{wheel}")"/*.whl "{dest_dir}/"'
+        CIBW_REPAIR_WHEEL_COMMAND_LINUX: bash -c 'mkdir -p "{dest_dir}" && cp "{wheel}" "{dest_dir}/"'
         CIBW_REPAIR_WHEEL_COMMAND_MACOS: bash -c 'mkdir -p "{dest_dir}" && cp "{wheel}" "{dest_dir}/"'
         CIBW_TEST_REQUIRES: cmake
         CIBW_TEST_COMMAND: python {project}/packages/z3-static/scripts/smoke_test_staticlib.py

--- a/.github/workflows/z3_static_wheel.yml
+++ b/.github/workflows/z3_static_wheel.yml
@@ -62,6 +62,11 @@ jobs:
           arch: ${{ matrix.arch }}
           platform-tag: ${{ matrix.platform_tag }}
           z3-tag: ${{ inputs.z3_tag }}
+      - name: Retag Linux wheel
+        if: startsWith(matrix.platform_tag, 'manylinux_')
+        run: |
+          python -m pip install wheel
+          python -m wheel tags --remove --platform-tag "${{ matrix.platform_tag }}" wheelhouse/*.whl
       - name: Upload wheel artifact
         uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
## Summary

- Retag Linux z3-static wheels after cibuildwheel finishes, before uploading artifacts.
- This converts unsupported `linux_*` wheel tags to the workflow-provided `manylinux_2_28_*` tags while updating wheel metadata via `python -m wheel tags`.