### PR TITLE
Expose z3-static CMake config CLI

### DIFF
--- a/.github/actions/z3-static-wheel/action.yml
+++ b/.github/actions/z3-static-wheel/action.yml
@@ -13,6 +13,10 @@ inputs:
   z3-tag:
     description: Upstream Z3 git tag
     required: true
+  version-suffix:
+    description: Python package version suffix
+    required: false
+    default: ""
 runs:
   using: composite
   steps:
@@ -22,6 +26,7 @@ runs:
         set -euo pipefail
         version="${{ inputs.z3-tag }}"
         version="${version#z3-}"
+        version="${version}${{ inputs.version-suffix }}"
         printf '%s\n' \
           '"""Version generated from the upstream Z3 release tag."""' \
           '' \

--- a/.github/workflows/z3_static_wheel.yml
+++ b/.github/workflows/z3_static_wheel.yml
@@ -7,6 +7,10 @@ on:
         description: Upstream Z3 tag
         required: true
         default: z3-4.16.0
+      version_suffix:
+        description: Python package version suffix, such as .post1
+        required: false
+        default: ""
       publish:
         description: Publish to PyPI
         type: boolean
@@ -62,6 +66,7 @@ jobs:
           arch: ${{ matrix.arch }}
           platform-tag: ${{ matrix.platform_tag }}
           z3-tag: ${{ inputs.z3_tag }}
+          version-suffix: ${{ inputs.version_suffix }}
       - name: Retag Linux wheel
         if: startsWith(matrix.platform_tag, 'manylinux_')
         run: |
@@ -83,6 +88,13 @@ jobs:
         working-directory: packages/z3-static
         run: |
           python -m pip install build
+          version="${{ inputs.z3_tag }}"
+          version="${version#z3-}${{ inputs.version_suffix }}"
+          printf '%s\n' \
+            '"""Version generated from the upstream Z3 release tag."""' \
+            '' \
+            "__version__ = \"${version}\"" \
+            > z3_static/_version.py
           python -m build --sdist
       - name: Upload sdist artifact
         uses: actions/upload-artifact@v4

--- a/packages/z3-static/README.md
+++ b/packages/z3-static/README.md
@@ -18,6 +18,24 @@ import z3_static
 print(z3_static.get_cmake_dir())
 ```
 
+Or from a build script:
+
+```bash
+python -m z3_static.config --cmake-dir
+```
+
+For CMake projects, pass the reported directory to `find_package`:
+
+```cmake
+find_package(Python COMPONENTS Interpreter REQUIRED)
+execute_process(
+  COMMAND "${Python_EXECUTABLE}" -m z3_static.config --cmake-dir
+  OUTPUT_STRIP_TRAILING_WHITESPACE
+  OUTPUT_VARIABLE Z3_DIR
+)
+find_package(Z3 CONFIG REQUIRED)
+```
+
 ## Local Build
 
 Build a wheel from an upstream Z3 tag:

--- a/packages/z3-static/scripts/smoke_test_staticlib.py
+++ b/packages/z3-static/scripts/smoke_test_staticlib.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import os
 import shutil
 import subprocess
 import sys
@@ -17,10 +16,24 @@ def run(cmd: list[str], *, cwd: Path) -> None:
     subprocess.check_call(cmd, cwd=cwd)
 
 
+def get_cmake_dir_from_config() -> str:
+    """Return the CMake directory reported by the z3_static.config CLI."""
+    output = subprocess.check_output(
+        [sys.executable, "-m", "z3_static.config", "--cmake-dir"], text=True
+    )
+    cmake_dir = output.strip()
+    if cmake_dir != z3_static.get_cmake_dir():
+        raise RuntimeError(
+            f"Unexpected z3_static.config --cmake-dir output: {cmake_dir}"
+        )
+    return cmake_dir
+
+
 def main() -> None:
     cmake = shutil.which("cmake")
     if not cmake:
         raise RuntimeError("cmake is required")
+    z3_cmake_dir = get_cmake_dir_from_config()
 
     with tempfile.TemporaryDirectory() as tmp:
         root = Path(tmp)
@@ -52,9 +65,10 @@ int main() {
         )
 
         build = root / "build"
-        env = os.environ.copy()
-        env["Z3_DIR"] = z3_static.get_cmake_dir()
-        run([cmake, "-S", str(root), "-B", str(build), f"-DZ3_DIR={z3_static.get_cmake_dir()}"], cwd=root)
+        run(
+            [cmake, "-S", str(root), "-B", str(build), f"-DZ3_DIR={z3_cmake_dir}"],
+            cwd=root,
+        )
         if sys.platform == "win32":
             run([cmake, "--build", str(build), "--config", "Release"], cwd=root)
             exe = build / "Release" / "smoke.exe"

--- a/packages/z3-static/z3_static/config.py
+++ b/packages/z3-static/z3_static/config.py
@@ -1,0 +1,30 @@
+"""Command-line configuration helpers for z3-static."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+
+from . import get_cmake_dir
+
+
+def main(argv: list[str] | None = None) -> None:
+    """Print z3-static configuration paths."""
+    parser = argparse.ArgumentParser(
+        description="Get configuration information needed to compile with z3-static"
+    )
+    parser.add_argument(
+        "--cmake-dir", action="store_true", help="Print Z3 CMake package directory"
+    )
+
+    args = parser.parse_args(argv)
+    if argv is None and len(sys.argv) == 1:
+        parser.print_help()
+        return
+
+    if args.cmake_dir:
+        print(get_cmake_dir())
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Add `python -m z3_static.config --cmake-dir` as a stable way for native build systems to locate the packaged Z3 CMake files.
- Exercise the CLI in the static library smoke test and document the CMake integration pattern.
- Allow the z3-static wheel workflow to publish package-only post releases such as `4.16.0.post1` without changing the upstream Z3 tag.

## Validation
- `python -m compileall packages/z3-static/z3_static packages/z3-static/scripts/smoke_test_staticlib.py`
- `PYTHONPATH=packages/z3-static python -m z3_static.config --cmake-dir`
- `PYTHONPATH=packages/z3-static python -m z3_static.config`