### PR TITLE
Fix self-hosted + stable builds, add nightly triggers

### DIFF
--- a/.github/workflows/wheel_applesiliconmac.yaml
+++ b/.github/workflows/wheel_applesiliconmac.yaml
@@ -7,11 +7,13 @@
 #
 # Triggers:
 #   * schedule          -> nightly build (mlc-ai-nightly-* / mlc-llm-nightly-*).
+#   * push (main)       -> nightly build + deploy (tracks latest main).
 #   * pull_request      -> nightly build for CI only; deploy is skipped.
 #   * workflow_dispatch -> stable release build (mlc-ai-* / mlc-llm-*) from the
 #                          `tag` input, checked out via MLC_STABLE_BUILD_VER
-#                          (see sync_package.py). The tag must exist in both
-#                          mlc-ai/relax and mlc-ai/mlc-llm.
+#                          (see sync_package.py); the tag must exist in both
+#                          mlc-ai/relax and mlc-ai/mlc-llm. Leave the tag empty
+#                          to run a nightly build on demand.
 #
 # Usage (stable): Actions -> "Wheel-AppleSiliconMac" -> Run workflow -> tag = v0.20.0
 name: Wheel-AppleSiliconMac
@@ -20,8 +22,12 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: "Stable release tag to build; must exist in both mlc-ai/relax and mlc-ai/mlc-llm (e.g. v0.20.0)"
-        required: true
+        description: "Stable release tag to build (e.g. v0.20.0); must exist in both mlc-ai/relax and mlc-ai/mlc-llm. Leave empty to run a nightly build."
+        required: false
+        default: ""
+  push:
+    branches:
+      - main
   pull_request:
     branches:
       - main
@@ -35,9 +41,10 @@ jobs:
       run:
         shell: 'bash -l {0}'
     env:
-      # 'stable' on a manual (workflow_dispatch) run, 'nightly' otherwise
-      # (scheduled nightly build or pull_request CI).
-      PKG_KIND: ${{ github.event_name == 'workflow_dispatch' && 'stable' || 'nightly' }}
+      # 'stable' only for a manual (workflow_dispatch) run that supplies a tag;
+      # nightly otherwise (schedule, push to main, pull_request, or a tagless
+      # manual run).
+      PKG_KIND: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.tag != '' && 'stable' || 'nightly' }}
       # Empty for nightly; the requested tag for stable. sync_package.py checks this
       # tag out for stable builds and errors out if it is empty on a stable build.
       MLC_STABLE_BUILD_VER: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.tag || '' }}

--- a/.github/workflows/wheel_manylinux.yaml
+++ b/.github/workflows/wheel_manylinux.yaml
@@ -6,14 +6,16 @@
 #   * schedule          -> nightly build. Package names mlc-ai-nightly-* /
 #                          mlc-llm-nightly-*, built from the tip of origin/mlc (tvm)
 #                          and origin/main (mlc-llm).
+#   * push (main)       -> nightly build + deploy, so the nightly wheels track the
+#                          latest main.
 #   * pull_request      -> nightly build for CI only. The deploy step is skipped
 #                          (guarded by `github.ref == 'refs/heads/main'`).
-#   * workflow_dispatch -> stable release build. Package names mlc-ai-* / mlc-llm-*,
-#                          built from the `tag` input. The same tag is checked out in
-#                          both mlc-ai/relax and mlc-ai/mlc-llm (via MLC_STABLE_BUILD_VER,
-#                          see sync_package.py), so it must exist in both repos. Each
-#                          stable VERSION is its own prune group, so it stays on the
-#                          index permanently.
+#   * workflow_dispatch -> stable release build when a `tag` is given: package names
+#                          mlc-ai-* / mlc-llm-*, the tag checked out in both
+#                          mlc-ai/relax and mlc-ai/mlc-llm (via MLC_STABLE_BUILD_VER,
+#                          see sync_package.py), and each stable VERSION is its own
+#                          prune group so it stays on the index permanently. Run it
+#                          with an empty tag to kick a nightly build on demand.
 #
 # Usage (stable): Actions -> "Wheel-Manylinux" -> Run workflow -> tag = v0.20.0
 name: Wheel-Manylinux
@@ -22,8 +24,12 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: "Stable release tag to build; must exist in both mlc-ai/relax and mlc-ai/mlc-llm (e.g. v0.20.0)"
-        required: true
+        description: "Stable release tag to build (e.g. v0.20.0); must exist in both mlc-ai/relax and mlc-ai/mlc-llm. Leave empty to run a nightly build."
+        required: false
+        default: ""
+  push:
+    branches:
+      - main
   pull_request:
     branches:
       - main
@@ -49,9 +55,10 @@ jobs:
 
     runs-on: [self-hosted, Linux, X64]
     env:
-      # 'stable' on a manual (workflow_dispatch) run, 'nightly' otherwise
-      # (scheduled nightly build or pull_request CI).
-      PKG_KIND: ${{ github.event_name == 'workflow_dispatch' && 'stable' || 'nightly' }}
+      # 'stable' only for a manual (workflow_dispatch) run that supplies a tag;
+      # nightly otherwise (schedule, push to main, pull_request, or a tagless
+      # manual run).
+      PKG_KIND: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.tag != '' && 'stable' || 'nightly' }}
       # Empty for nightly; the requested tag for stable. sync_package.py checks this
       # tag out for stable builds and errors out if it is empty on a stable build.
       MLC_STABLE_BUILD_VER: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.tag || '' }}
@@ -65,7 +72,14 @@ jobs:
         rm -rf conda
         ln -s 3rdparty/tlcpack/conda conda
     - name: Checkout source
+      env:
+        IMAGE: ${{ matrix.config.image }}
       run: |
+        # Self-hosted runners persist the workspace between runs; a prior or
+        # cancelled build leaves root-owned files under tvm/ and mlc-llm/ that
+        # actions/checkout's git clean cannot remove. Delete them as root (inside
+        # the build image) before cloning, or `git clone` fails on the stale dir.
+        docker/bash.sh --no-gpu $IMAGE ./scripts/cleanup_workspace.sh
         git clone https://github.com/mlc-ai/relax tvm --recursive
         git clone https://github.com/mlc-ai/mlc-llm mlc-llm --recursive
     - name: Sync MLC AI Package

--- a/.github/workflows/wheel_win.yaml
+++ b/.github/workflows/wheel_win.yaml
@@ -4,11 +4,13 @@
 #
 # Triggers:
 #   * schedule          -> nightly build (mlc-ai-nightly-* / mlc-llm-nightly-*).
+#   * push (main)       -> nightly build + deploy (tracks latest main).
 #   * pull_request      -> nightly build for CI only; deploy is skipped.
 #   * workflow_dispatch -> stable release build (mlc-ai-* / mlc-llm-*) from the
 #                          `tag` input, checked out via MLC_STABLE_BUILD_VER
-#                          (see sync_package.py). The tag must exist in both
-#                          mlc-ai/relax and mlc-ai/mlc-llm.
+#                          (see sync_package.py); the tag must exist in both
+#                          mlc-ai/relax and mlc-ai/mlc-llm. Leave the tag empty
+#                          to run a nightly build on demand.
 #
 # Usage (stable): Actions -> "Wheel-Windows" -> Run workflow -> tag = v0.20.0
 name: Wheel-Windows
@@ -17,8 +19,12 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: "Stable release tag to build; must exist in both mlc-ai/relax and mlc-ai/mlc-llm (e.g. v0.20.0)"
-        required: true
+        description: "Stable release tag to build (e.g. v0.20.0); must exist in both mlc-ai/relax and mlc-ai/mlc-llm. Leave empty to run a nightly build."
+        required: false
+        default: ""
+  push:
+    branches:
+      - main
   pull_request:
     branches:
       - main
@@ -32,9 +38,10 @@ jobs:
       run:
         shell: 'cmd /C call {0}'
     env:
-      # 'stable' on a manual (workflow_dispatch) run, 'nightly' otherwise
-      # (scheduled nightly build or pull_request CI).
-      PKG_KIND: ${{ github.event_name == 'workflow_dispatch' && 'stable' || 'nightly' }}
+      # 'stable' only for a manual (workflow_dispatch) run that supplies a tag;
+      # nightly otherwise (schedule, push to main, pull_request, or a tagless
+      # manual run).
+      PKG_KIND: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.tag != '' && 'stable' || 'nightly' }}
       # Empty for nightly; the requested tag for stable. sync_package.py checks this
       # tag out for stable builds and errors out if it is empty on a stable build.
       MLC_STABLE_BUILD_VER: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.tag || '' }}

--- a/scripts/cleanup_workspace.sh
+++ b/scripts/cleanup_workspace.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 
-rm -rf /workspace/tvm/*
-rm -rf /workspace/mlc-llm/*
-rm -rf /workspace/nvshmem
+# Remove the per-build source checkouts and generated artifacts. This runs as
+# root inside the build container so it can delete root-owned files the build
+# left behind; otherwise the self-hosted runner's next `git clone` fails with
+# "destination path 'tvm' already exists". Remove the whole directories (not
+# just their contents) so a stale .git can't linger either.
+rm -rf /workspace/tvm /workspace/mlc-llm /workspace/nvshmem

--- a/scripts/sync_package.py
+++ b/scripts/sync_package.py
@@ -29,7 +29,12 @@ def checkout_source(src, tag):
             raise RuntimeError(msg)
 
     run_cmd(["git", "checkout", "-f", tag])
-    run_cmd(["git", "submodule", "update"])
+    # --init --recursive so nested submodules are synced to the tag too: e.g.
+    # mlc-llm pins 3rdparty/tvm, which pins its own 3rdparty/tvm-ffi. A plain
+    # `submodule update` moves 3rdparty/tvm to the tag but leaves the nested
+    # tvm-ffi at whatever the initial clone had, so tvm gets built against a
+    # mismatched tvm-ffi.
+    run_cmd(["git", "submodule", "update", "--init", "--recursive"])
     print("git checkout %s" % tag)
 
 


### PR DESCRIPTION
Self-hosted cleanup: a prior or cancelled manylinux build leaves root-owned files under tvm/ and mlc-llm/ that actions/checkout's git clean (running as the runner user) cannot remove, so the next `git clone` fails with "destination path 'tvm' already exists". Clean the workspace as root inside the build image before cloning, and have cleanup_workspace.sh remove the whole directories (including .git) instead of just their contents, so a dirty runner self-heals rather than deadlocking on a run that fails before the post-build cleanup.

Stable submodule sync: sync_package.py's tag checkout ran a non-recursive `git submodule update`, which moves direct submodules to the tag but leaves nested ones stale. mlc-llm pins 3rdparty/tvm, which pins its own 3rdparty/tvm-ffi, so e.g. the v0.20.0 tvm was compiled against a mismatched tvm-ffi and failed. Use
`git submodule update --init --recursive`.

Triggers: build a nightly (and deploy) on push to main so the nightly wheels track the latest main, and make the `tag` input optional so a tagless workflow_dispatch runs a nightly on demand instead of a stable build. Pull requests still build without deploying.