### PR TITLE
Fail builds on version-sync errors; fix macOS wheel platform tags

### DIFF
--- a/.github/workflows/wheel_applesiliconmac.yaml
+++ b/.github/workflows/wheel_applesiliconmac.yaml
@@ -7,11 +7,13 @@
 #
 # Triggers:
 #   * schedule          -> nightly build (mlc-ai-nightly-* / mlc-llm-nightly-*).
+#   * push (main)       -> nightly build + deploy (tracks latest main).
 #   * pull_request      -> nightly build for CI only; deploy is skipped.
 #   * workflow_dispatch -> stable release build (mlc-ai-* / mlc-llm-*) from the
 #                          `tag` input, checked out via MLC_STABLE_BUILD_VER
-#                          (see sync_package.py). The tag must exist in both
-#                          mlc-ai/relax and mlc-ai/mlc-llm.
+#                          (see sync_package.py); the tag must exist in both
+#                          mlc-ai/relax and mlc-ai/mlc-llm. Leave the tag empty
+#                          to run a nightly build on demand.
 #
 # Usage (stable): Actions -> "Wheel-AppleSiliconMac" -> Run workflow -> tag = v0.20.0
 name: Wheel-AppleSiliconMac
@@ -20,8 +22,12 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: "Stable release tag to build; must exist in both mlc-ai/relax and mlc-ai/mlc-llm (e.g. v0.20.0)"
-        required: true
+        description: "Stable release tag to build (e.g. v0.20.0); must exist in both mlc-ai/relax and mlc-ai/mlc-llm. Leave empty to run a nightly build."
+        required: false
+        default: ""
+  push:
+    branches:
+      - main
   pull_request:
     branches:
       - main
@@ -35,9 +41,10 @@ jobs:
       run:
         shell: 'bash -l {0}'
     env:
-      # 'stable' on a manual (workflow_dispatch) run, 'nightly' otherwise
-      # (scheduled nightly build or pull_request CI).
-      PKG_KIND: ${{ github.event_name == 'workflow_dispatch' && 'stable' || 'nightly' }}
+      # 'stable' only for a manual (workflow_dispatch) run that supplies a tag;
+      # nightly otherwise (schedule, push to main, pull_request, or a tagless
+      # manual run).
+      PKG_KIND: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.tag != '' && 'stable' || 'nightly' }}
       # Empty for nightly; the requested tag for stable. sync_package.py checks this
       # tag out for stable builds and errors out if it is empty on a stable build.
       MLC_STABLE_BUILD_VER: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.tag || '' }}

--- a/.github/workflows/wheel_manylinux.yaml
+++ b/.github/workflows/wheel_manylinux.yaml
@@ -6,14 +6,16 @@
 #   * schedule          -> nightly build. Package names mlc-ai-nightly-* /
 #                          mlc-llm-nightly-*, built from the tip of origin/mlc (tvm)
 #                          and origin/main (mlc-llm).
+#   * push (main)       -> nightly build + deploy, so the nightly wheels track the
+#                          latest main.
 #   * pull_request      -> nightly build for CI only. The deploy step is skipped
 #                          (guarded by `github.ref == 'refs/heads/main'`).
-#   * workflow_dispatch -> stable release build. Package names mlc-ai-* / mlc-llm-*,
-#                          built from the `tag` input. The same tag is checked out in
-#                          both mlc-ai/relax and mlc-ai/mlc-llm (via MLC_STABLE_BUILD_VER,
-#                          see sync_package.py), so it must exist in both repos. Each
-#                          stable VERSION is its own prune group, so it stays on the
-#                          index permanently.
+#   * workflow_dispatch -> stable release build when a `tag` is given: package names
+#                          mlc-ai-* / mlc-llm-*, the tag checked out in both
+#                          mlc-ai/relax and mlc-ai/mlc-llm (via MLC_STABLE_BUILD_VER,
+#                          see sync_package.py), and each stable VERSION is its own
+#                          prune group so it stays on the index permanently. Run it
+#                          with an empty tag to kick a nightly build on demand.
 #
 # Usage (stable): Actions -> "Wheel-Manylinux" -> Run workflow -> tag = v0.20.0
 name: Wheel-Manylinux
@@ -22,8 +24,12 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: "Stable release tag to build; must exist in both mlc-ai/relax and mlc-ai/mlc-llm (e.g. v0.20.0)"
-        required: true
+        description: "Stable release tag to build (e.g. v0.20.0); must exist in both mlc-ai/relax and mlc-ai/mlc-llm. Leave empty to run a nightly build."
+        required: false
+        default: ""
+  push:
+    branches:
+      - main
   pull_request:
     branches:
       - main
@@ -49,9 +55,10 @@ jobs:
 
     runs-on: [self-hosted, Linux, X64]
     env:
-      # 'stable' on a manual (workflow_dispatch) run, 'nightly' otherwise
-      # (scheduled nightly build or pull_request CI).
-      PKG_KIND: ${{ github.event_name == 'workflow_dispatch' && 'stable' || 'nightly' }}
+      # 'stable' only for a manual (workflow_dispatch) run that supplies a tag;
+      # nightly otherwise (schedule, push to main, pull_request, or a tagless
+      # manual run).
+      PKG_KIND: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.tag != '' && 'stable' || 'nightly' }}
       # Empty for nightly; the requested tag for stable. sync_package.py checks this
       # tag out for stable builds and errors out if it is empty on a stable build.
       MLC_STABLE_BUILD_VER: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.tag || '' }}
@@ -65,7 +72,14 @@ jobs:
         rm -rf conda
         ln -s 3rdparty/tlcpack/conda conda
     - name: Checkout source
+      env:
+        IMAGE: ${{ matrix.config.image }}
       run: |
+        # Self-hosted runners persist the workspace between runs; a prior or
+        # cancelled build leaves root-owned files under tvm/ and mlc-llm/ that
+        # actions/checkout's git clean cannot remove. Delete them as root (inside
+        # the build image) before cloning, or `git clone` fails on the stale dir.
+        docker/bash.sh --no-gpu $IMAGE ./scripts/cleanup_workspace.sh
         git clone https://github.com/mlc-ai/relax tvm --recursive
         git clone https://github.com/mlc-ai/mlc-llm mlc-llm --recursive
     - name: Sync MLC AI Package

--- a/.github/workflows/wheel_win.yaml
+++ b/.github/workflows/wheel_win.yaml
@@ -4,11 +4,13 @@
 #
 # Triggers:
 #   * schedule          -> nightly build (mlc-ai-nightly-* / mlc-llm-nightly-*).
+#   * push (main)       -> nightly build + deploy (tracks latest main).
 #   * pull_request      -> nightly build for CI only; deploy is skipped.
 #   * workflow_dispatch -> stable release build (mlc-ai-* / mlc-llm-*) from the
 #                          `tag` input, checked out via MLC_STABLE_BUILD_VER
-#                          (see sync_package.py). The tag must exist in both
-#                          mlc-ai/relax and mlc-ai/mlc-llm.
+#                          (see sync_package.py); the tag must exist in both
+#                          mlc-ai/relax and mlc-ai/mlc-llm. Leave the tag empty
+#                          to run a nightly build on demand.
 #
 # Usage (stable): Actions -> "Wheel-Windows" -> Run workflow -> tag = v0.20.0
 name: Wheel-Windows
@@ -17,8 +19,12 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: "Stable release tag to build; must exist in both mlc-ai/relax and mlc-ai/mlc-llm (e.g. v0.20.0)"
-        required: true
+        description: "Stable release tag to build (e.g. v0.20.0); must exist in both mlc-ai/relax and mlc-ai/mlc-llm. Leave empty to run a nightly build."
+        required: false
+        default: ""
+  push:
+    branches:
+      - main
   pull_request:
     branches:
       - main
@@ -32,9 +38,10 @@ jobs:
       run:
         shell: 'cmd /C call {0}'
     env:
-      # 'stable' on a manual (workflow_dispatch) run, 'nightly' otherwise
-      # (scheduled nightly build or pull_request CI).
-      PKG_KIND: ${{ github.event_name == 'workflow_dispatch' && 'stable' || 'nightly' }}
+      # 'stable' only for a manual (workflow_dispatch) run that supplies a tag;
+      # nightly otherwise (schedule, push to main, pull_request, or a tagless
+      # manual run).
+      PKG_KIND: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.tag != '' && 'stable' || 'nightly' }}
       # Empty for nightly; the requested tag for stable. sync_package.py checks this
       # tag out for stable builds and errors out if it is empty on a stable build.
       MLC_STABLE_BUILD_VER: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.tag || '' }}

--- a/scripts/build_mlc_ai_lib_osx.sh
+++ b/scripts/build_mlc_ai_lib_osx.sh
@@ -3,7 +3,8 @@
 set -e
 set -u
 
-MACOSX_DEPLOYMENT_TARGET=${MACOSX_DEPLOYMENT_TARGET:-14.0}
+# export so `pip wheel` tags the wheel with the deployment target, not the host macOS version
+export MACOSX_DEPLOYMENT_TARGET=${MACOSX_DEPLOYMENT_TARGET:-14.0}
 
 python --version
 python -m pip install wheel

--- a/scripts/build_mlc_llm_lib_osx.sh
+++ b/scripts/build_mlc_llm_lib_osx.sh
@@ -3,7 +3,8 @@
 set -e
 set -u
 
-MACOSX_DEPLOYMENT_TARGET=${MACOSX_DEPLOYMENT_TARGET:-14.0}
+# export so `pip wheel` tags the wheel with the deployment target, not the host macOS version
+export MACOSX_DEPLOYMENT_TARGET=${MACOSX_DEPLOYMENT_TARGET:-14.0}
 
 python --version
 python -m pip install wheel

--- a/scripts/cleanup_workspace.sh
+++ b/scripts/cleanup_workspace.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 
-rm -rf /workspace/tvm/*
-rm -rf /workspace/mlc-llm/*
-rm -rf /workspace/nvshmem
+# Remove the per-build source checkouts and generated artifacts. This runs as
+# root inside the build container so it can delete root-owned files the build
+# left behind; otherwise the self-hosted runner's next `git clone` fails with
+# "destination path 'tvm' already exists". Remove the whole directories (not
+# just their contents) so a stale .git can't linger either.
+rm -rf /workspace/tvm /workspace/mlc-llm /workspace/nvshmem

--- a/scripts/sync_package.py
+++ b/scripts/sync_package.py
@@ -69,9 +69,19 @@ def name_with_gpu(args, package_name):
 
 
 def run_version_py(args):
-    # Run version.py to bump the version
     version_py = os.path.join(args.package, "version.py")
-    subprocess.run([sys.executable, version_py, "--git-describe"])
+    if __stable_build__ and "nightly" not in args.package_name:
+        # stable version comes from the requested tag; the tag's version.py may predate fixes
+        rewrites = [
+            (r'(?m)(?<=(?<![^\n])version = ")[^\n"]+(?=")', __stable_build__.lstrip("v")),
+        ]
+        update(os.path.join(args.package, "pyproject.toml"), rewrites, args.dry_run)
+    elif os.path.exists(version_py):
+        # check=True so wheels never ship the placeholder version from pyproject.toml
+        subprocess.run([sys.executable, version_py, "--git-describe"], check=True)
+    else:
+        # tvm stamps its own version at build time
+        print("%s not found; skipping version bump for %s" % (version_py, args.package))
     # Update package name
     rewrites = [
         (r'(?m)(?<=(?<![^\n])name = ")[^\n"]+(?=")', name_with_gpu(args, args.package_name)),

--- a/scripts/sync_package.py
+++ b/scripts/sync_package.py
@@ -29,7 +29,12 @@ def checkout_source(src, tag):
             raise RuntimeError(msg)
 
     run_cmd(["git", "checkout", "-f", tag])
-    run_cmd(["git", "submodule", "update"])
+    # --init --recursive so nested submodules are synced to the tag too: e.g.
+    # mlc-llm pins 3rdparty/tvm, which pins its own 3rdparty/tvm-ffi. A plain
+    # `submodule update` moves 3rdparty/tvm to the tag but leaves the nested
+    # tvm-ffi at whatever the initial clone had, so tvm gets built against a
+    # mismatched tvm-ffi.
+    run_cmd(["git", "submodule", "update", "--init", "--recursive"])
     print("git checkout %s" % tag)
 
 


### PR DESCRIPTION
Guardrails and fixes for the wheel pipeline, addressing the packaging side of mlc-ai/mlc-llm#3516 / mlc-ai/mlc-llm#3517 (plus the pre-existing self-hosted/stable build fixes on this branch):

1. **`sync_package.py`: run `version.py` with `check=True`.** Its failure was silently swallowed, so every mlc-llm wheel on every platform shipped with the placeholder version `0.20.0.dev0` (pyproject.toml default). Under PEP 440 `0.20.0.dev0 < 0.20.dev162`, so pip kept resolving users onto the stale Sep-2025 nightlies, which dlopen-fail against current mlc-ai wheels (mlc-ai/mlc-llm#3516). The underlying version.py crash is fixed in mlc-ai/mlc-llm#3522; this makes any future sync failure fail the build instead of shipping wrong wheels. The now-missing `tvm/version.py` is skipped explicitly (tvm's build backend stamps its own version).

2. **Export `MACOSX_DEPLOYMENT_TARGET` in the osx build scripts.** The wheel platform tag honors the env var; unexported, wheels were tagged with the build host's macOS version. `macos-latest` runners are macOS 26 now, so wheels came out `macosx_26_0_arm64` — uninstallable on macOS < 26 even though the binaries target 14.0. With the export they are tagged `macosx_14_0_arm64`.

Verified locally against a scratch checkout of current mlc-llm main:

* sync produces `name = "mlc-llm-nightly-cpu"`, `version = "0.26.dev3"`;
* sync against pre-#3522 mlc-llm now exits 1 (previously exit 0);
* missing `tvm/version.py` is skipped, name rewrite still applied;
* with wheels `0.20.dev162` / `0.20.0.dev0` / `0.26.dev3` all present in an index, `pip install --pre` selects `0.26.dev3`, so resolution self-heals once the first fixed nightly publishes.


**Update:** stable builds now stamp the version directly from `MLC_STABLE_BUILD_VER` (the requested tag) instead of running the tag's `version.py` — rebuilding `v0.20.0` would otherwise fail, since the tag predates mlc-ai/mlc-llm#3522. Verified against the real `v0.20.0` tag: produces `name = "mlc-llm-cpu"`, `version = "0.20.0"` (so stable installs stop requiring `--pre`); nightly path and tvm no-version-line no-op re-verified.
